### PR TITLE
feat: Add auto-submit functionality for Sales Orders from Leases

### DIFF
--- a/propms/lease_invoice.py
+++ b/propms/lease_invoice.py
@@ -77,6 +77,9 @@ def makeInvoice(
         doc.calculate_taxes_and_totals()
         doc.save()
         
+        if doctype == "Sales Order" and frappe.db.get_single_value("Property Management Settings", "auto_submit_sales_order"):
+            doc.submit()
+
         # Check if auto submit is enabled in Property Management Settings
         if doctype == "Sales Invoice" and frappe.db.get_single_value("Property Management Settings", "auto_submit_sales_invoice"):
             doc.submit()

--- a/propms/property_management_solution/doctype/property_management_settings/property_management_settings.json
+++ b/propms/property_management_solution/doctype/property_management_settings/property_management_settings.json
@@ -20,6 +20,7 @@
   "make_single_invoice_on_lease",
   "make_invoice_schedule_up_to_tomorrow_only",
   "use_valid_from_date",
+  "auto_submit_sales_order",
   "auto_submit_sales_invoice",
   "submit_maintenance_stock_entry",
   "column_break_14",
@@ -148,12 +149,18 @@
    "fieldname": "make_invoice_schedule_up_to_tomorrow_only",
    "fieldtype": "Check",
    "label": "Make Invoice Schedule up to tomorrow only"
+  },
+  {
+   "default": "0",
+   "fieldname": "auto_submit_sales_order",
+   "fieldtype": "Check",
+   "label": "Auto Submit Sales Order From Lease"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-06-26 16:00:42.304877",
+ "modified": "2026-03-27 18:16:34.603663",
  "modified_by": "Administrator",
  "module": "Property Management Solution",
  "name": "Property Management Settings",
@@ -181,6 +188,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
This commit adds a new 'auto_submit_sales_order' Check field to the 'Property Management Settings' DocType, allowing users to control whether Sales Orders generated from Leases should be automatically submitted.

It also updates the 'makeInvoice' logic in 'propms/lease_invoice.py' to evaluate this setting, and if enabled, immediately submit the newly created Sales Order document after generation.

This feature streamlines user workflow by avoiding manual state transitions, aligning Sales Order generation behavior with the existing auto-submit functionality for Sales Invoices.