### PR TITLE
Add daily lease status automation for Upcoming, Active, and Expired leases

### DIFF
--- a/propms/hooks.py
+++ b/propms/hooks.py
@@ -124,6 +124,9 @@ doc_events = {
 
 
 scheduler_events = {
+	"daily_long": [
+		"propms.property_management_solution.doctype.lease.lease.update_lease_statuses"
+	],
     "daily": [
         "propms.auto_custom.statusChangeBeforeLeaseExpire",
         "propms.auto_custom.statusChangeAfterLeaseExpire",

--- a/propms/property_management_solution/doctype/lease/lease.json
+++ b/propms/property_management_solution/doctype/lease/lease.json
@@ -318,7 +318,7 @@
    "fieldname": "lease_status",
    "fieldtype": "Select",
    "label": "Lease Status",
-   "options": "\nActive\nClosed\nNot Materialized\nRenewal to Previous Lease\nAdendum to Previous Lease\nVacating\nDraft\nTerminated"
+   "options": "\nDraft\nUpcoming\nActive\nExpired\nClosed\nNot Materialized\nRenewal to Previous Lease\nAdendum to Previous Lease\nVacating\nTerminated"
   },
   {
    "default": "0",

--- a/propms/property_management_solution/doctype/lease/lease.py
+++ b/propms/property_management_solution/doctype/lease/lease.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
-from frappe.utils import add_days, today, getdate, add_months, get_datetime, now
+from frappe.utils import add_days, today, getdate, add_months, get_datetime, now, nowdate
 from propms.auto_custom import app_error_log, makeInvoiceSchedule, getDateMonthDiff
 from frappe import _
 
@@ -108,6 +108,123 @@ class Lease(Document):
                         frappe.msgprint(_(f'Property "{prop}" has now been set <b>On Lease from Active</b> for Lease "{self.name}"'))
         except Exception as e:
             app_error_log(frappe.session.user, str(e))
+        self.set_lease_status()
+
+
+    def set_lease_status(self):
+        """
+        Set lease status on save.
+
+        Only system-controlled statuses are automatically changed:
+        Upcoming, Active, Expired.
+
+        All other statuses are considered manual and are not overwritten.
+        """
+
+        if self.lease_status not in get_system_controlled_statuses():
+            return
+
+        status = get_status_for_lease(self)
+
+        if status:
+            self.lease_status = status
+
+
+def get_system_controlled_statuses():
+    """
+    Statuses controlled by system automation.
+
+    Any lease_status outside this set is treated as manually controlled
+    and will not be overwritten by validate() or the daily scheduler.
+    """
+
+    return {"Upcoming", "Active", "Expired"}
+
+
+def update_lease_statuses():
+    """
+    Daily scheduler method.
+
+    Updates only system-controlled Lease statuses:
+    Upcoming, Active, Expired.
+
+    Uses frappe.db.set_value() to avoid full document save hooks,
+    and adds a timeline comment for audit visibility.
+    """
+
+    today_date = getdate(nowdate())
+    system_controlled_statuses = list(get_system_controlled_statuses())
+
+    leases = frappe.get_all(
+        "Lease",
+        fields=[
+            "name",
+            "lease_status",
+            "start_date",
+            "end_date",
+            "skip_end_date",
+        ],
+        filters=[
+            ["lease_status", "in", system_controlled_statuses],
+            ["docstatus", "<", 2],
+        ],
+    )
+
+    for lease in leases:
+        old_status = lease.lease_status
+        new_status = get_status_for_lease(lease, today_date)
+
+        if not new_status or new_status == old_status:
+            continue
+
+        frappe.db.set_value(
+            "Lease",
+            lease.name,
+            "lease_status",
+            new_status,
+            update_modified=True,
+        )
+
+        doc = frappe.get_doc("Lease", lease.name)
+        doc.add_comment(
+            "Info",
+            _(
+                "Lease Status automatically changed from {0} to {1} by daily scheduler."
+            ).format(old_status or "blank", new_status),
+        )
+
+    frappe.db.commit()
+
+
+def get_status_for_lease(lease, today_date=None):
+    """
+    Return calculated Lease Status.
+
+    Rules:
+    - Future start_date => Upcoming
+    - start_date <= today and end_date >= today => Active
+    - end_date < today => Expired
+    - If skip_end_date is checked, do not mark as Expired
+    - end_date equal to today remains Active until the next day
+    """
+
+    today_date = today_date or getdate(nowdate())
+
+    start_date = getdate(lease.start_date) if lease.start_date else None
+    end_date = getdate(lease.end_date) if lease.end_date else None
+    skip_end_date = bool(lease.skip_end_date)
+
+    if start_date and start_date > today_date:
+        return "Upcoming"
+
+    if not skip_end_date and end_date and end_date < today_date:
+        return "Expired"
+
+    if start_date and start_date <= today_date:
+        if skip_end_date or not end_date or end_date >= today_date:
+            return "Active"
+
+    return None
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary

This PR adds automated Lease Status updates for system-controlled lease statuses.

The automation updates leases between the following statuses based on lease dates:

- Upcoming
- Active
- Expired

The daily scheduler runs through `daily_long` and updates only leases that are already in one of the system-controlled statuses. Manual statuses such as Draft, Terminated, Closed, Vacating, Not Materialized, Renewal to Previous Lease, and Adendum to Previous Lease are intentionally not overwritten.

## Changes

- Added `set_lease_status()` on the Lease document controller.
- Added `get_system_controlled_statuses()` helper.
- Added `get_status_for_lease()` helper to calculate the correct status based on:
  - `start_date`
  - `end_date`
  - `skip_end_date`
- Added `update_lease_statuses()` scheduler method.
- Added timeline comments when the scheduler changes a Lease Status.
- Used `frappe.db.set_value()` for scheduler updates to avoid full document save hooks.
- Preserved audit visibility through `add_comment()` on the Lease timeline.

## Status Rules

| Condition | Result |
|---|---|
| `start_date` is in the future | Upcoming |
| `start_date <= today` and `end_date >= today` | Active |
| `end_date < today` | Expired |
| `skip_end_date` is checked | Will not be marked Expired |
| `end_date == today` | Remains Active until the next day |

## Manual Status Handling

Only these statuses are system-controlled:

- Upcoming
- Active
- Expired

Any other Lease Status is treated as manually controlled and is not updated automatically.

## Scheduler

The scheduler method is intended to run under `daily_long`:

```python
scheduler_events = {
    "daily_long": [
        "propms.property_management_solution.doctype.lease.lease.update_lease_statuses"
    ]
}