### PR TITLE
feat(property): add create cost center action

### DIFF
--- a/propms/property_management_solution/doctype/property/property.js
+++ b/propms/property_management_solution/doctype/property/property.js
@@ -3,7 +3,75 @@
 
 frappe.ui.form.on('Property', {
 	refresh: function(frm) {
+		if (!frm.is_new()) {
+			frm.add_custom_button(
+				__("Create Cost Center"),
+				function () {
+					let dialog = new frappe.ui.Dialog({
+						title: __("Create Cost Center"),
+						fields: [
+							{
+								fieldtype: "Data",
+								fieldname: "cost_center_name",
+								label: __("Cost Center Name"),
+								reqd: 1,
+							},
+							{
+								fieldtype: "Link",
+								fieldname: "parent_cost_center",
+								label: __("Parent Cost Center"),
+								options: "Cost Center",
+								reqd: 1,
+								get_query: function () {
+									return {
+										filters: {
+											is_group: 1,
+										},
+									};
+								},
+							},
+							{
+								fieldtype: "Link",
+								fieldname: "company",
+								label: __("Company"),
+								options: "Company",
+								reqd: 1,
+								default: frappe.defaults.get_default("Company"),
+							},
+						],
+						primary_action_label: __("Create"),
+						primary_action(values) {
+							frappe.call({
+								method: "frappe.client.insert",
+								args: {
+									doc: {
+										doctype: "Cost Center",
+										cost_center_name: values.cost_center_name,
+										parent_cost_center: values.parent_cost_center,
+										company: values.company,
+									},
+								},
+								callback: function (r) {
+									if (r.message) {
+										frm.set_value("cost_center", r.message.name);
 
+										frappe.show_alert({
+											message: __("Cost Center Created Successfully"),
+											indicator: "green",
+										});
+
+										dialog.hide();
+									}
+								},
+							});
+						},
+					});
+
+					dialog.show();
+				},
+				__("Actions"),
+			);
+		}
 	},
 	setup: function(frm) {
 		frm.set_query("cost_center", function() {


### PR DESCRIPTION
### PR Description:

  ## Summary
  - Added a Create Cost Center action on the Property form.
  - Opens a dialog to create a Cost Center with Cost Center Name, Parent Cost Center, and Company.
  - Sets the newly created Cost Center on the Property document after successful creation.

  ## Changes
  - Added custom button under Actions for saved Property records.
  - Added parent cost center filter to show only group cost centers.
  - Shows success alert after creating the Cost Center.