### PR TITLE
feat: allow configurable maximum active leases per property

### DIFF
--- a/propms/property_management_solution/doctype/lease/lease.py
+++ b/propms/property_management_solution/doctype/lease/lease.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
-from frappe.utils import add_days, today, getdate, add_months, get_datetime, now, nowdate
+from frappe.utils import add_days, today, getdate, add_months, get_datetime, now, nowdate, cint
 from propms.auto_custom import app_error_log, makeInvoiceSchedule, getDateMonthDiff
 from frappe import _
 
@@ -50,6 +50,7 @@ class Lease(Document):
             # Lease Status Validation: Prevent multiple active leases per property
             if self.lease_status == "Active":
                 for prop in properties:
+                    max_allowed = cint(frappe.db.get_value("Property", prop, "max_active_leases")) or cint(frappe.db.get_single_value("Property Management Settings", "max_active_leases")) or 1
                     # Query for other non-draft leases for the same property
                     conflicting_leases = frappe.db.get_all(
                         "Lease",
@@ -61,21 +62,18 @@ class Lease(Document):
                         },
                         fields=["name", "end_date", "lease_status"],
                     )
-                    for lease in conflicting_leases:
-                        # If end_date is blank or in the future, block activation
-                        if not lease["end_date"] or getdate(lease["end_date"]) > getdate(
-                            self.start_date
-                        ):
-                            msg = _(
-                                "Cannot activate lease <b>{0}</b> for property <b>{1}</b>.<br>Conflicting lease: <b>{2} (Status: {3}, End Date: {4})</b>"
-                            ).format(
-                                self.name,
-                                prop,
-                                lease["name"],
-                                lease["lease_status"],
-                                lease["end_date"] or "None",
-                            )
-                            frappe.throw(msg, frappe.ValidationError)
+                    active_conflicts = [
+                        l for l in conflicting_leases
+                        if not l["end_date"] or getdate(l["end_date"]) >= getdate(self.start_date)
+                    ]
+                    if len(active_conflicts) >= max_allowed:
+                        msg = _(
+                            "Cannot activate lease <b>{0}</b> for property <b>{1}</b>.<br><br>"
+                            "• <b>Max Allowed Active Leases:</b> {2}<br>"
+                            "• <b>Currently Active Leases:</b> {3}<br><br>"
+                            "<i>Please contact Administrator if you need to increase the limit for this property.</i>"
+                        ).format(self.name, prop, max_allowed, len(active_conflicts))
+                        frappe.throw(msg, title=_("Active Lease Limit Exceeded"))
 
             for prop in properties:
                 if (
@@ -106,6 +104,8 @@ class Lease(Document):
                             "Property", prop, "status", "On Lease"
                         )
                         frappe.msgprint(_(f'Property "{prop}" has now been set <b>On Lease from Active</b> for Lease "{self.name}"'))
+        except frappe.ValidationError:
+            raise
         except Exception as e:
             app_error_log(frappe.session.user, str(e))
         self.set_lease_status()

--- a/propms/property_management_solution/doctype/property/property.json
+++ b/propms/property_management_solution/doctype/property/property.json
@@ -37,6 +37,7 @@
   "smoking",
   "furnished",
   "status",
+  "max_active_leases",
   "section_break_22",
   "unit_assets",
   "column_break_24",
@@ -192,6 +193,13 @@
    "fieldtype": "Select",
    "label": "Status",
    "options": "Available\nBooked\nCommon Area (Not for lease)\nManaged for Customer\nOff Lease in 3 Months\nOn Lease\nOn Sale\nRemoved\nRenewal\nSold\nVacating\nIn Renovation"
+  },
+  {
+   "default": "0",
+   "description": "Max active leases allowed for this property. If 0, system setting will be used (default: 1).",
+   "fieldname": "max_active_leases",
+   "fieldtype": "Int",
+   "label": "Max Active Leases"
   },
   {
    "bold": 1,

--- a/propms/property_management_solution/doctype/property_management_settings/property_management_settings.json
+++ b/propms/property_management_solution/doctype/property_management_settings/property_management_settings.json
@@ -23,6 +23,7 @@
   "auto_submit_sales_order",
   "auto_submit_sales_invoice",
   "submit_maintenance_stock_entry",
+  "max_active_leases",
   "column_break_14",
   "maintenance_item_group",
   "allow_end_of_the_month",
@@ -155,6 +156,13 @@
    "fieldname": "auto_submit_sales_order",
    "fieldtype": "Check",
    "label": "Auto Submit Sales Order From Lease"
+  },
+  {
+   "default": "1",
+   "description": "Maximum number of active leases allowed per property. Defaults to 1.",
+   "fieldname": "max_active_leases",
+   "fieldtype": "Int",
+   "label": "Max Active Leases Per Property"
   }
  ],
  "index_web_pages_for_search": 1,


### PR DESCRIPTION
## Summary
  
  This PR introduces configurable active lease limits per property in PropMS, allowing properties to hold multiple active leases (defaulting to 1).
  
  ## Motivation
  
  Previously, lease validation strictly enforced a maximum of 1 active lease per property. This feature allows property managers to configure system-wise or per-property limits (e.g. 2, 3 active leases).
  
  ## Type of Change
  
  [✓] feat: A new feature
  
  ## Detailed Changes
  
  **Property Management Settings (property_management_settings.json):**
      - Added max_active_leases (Int, Default: 1) for global system default.
  **Property (property.json):**
      -Added max_active_leases (Int, Default: 0) for property-level overrides (0 falls back to system setting).
  **Lease Validation (lease.py):**
      -Enforced max_allowed check in Lease.validate() before activating a lease.
      -Formatted user-friendly error message dialog.
  

  ## Verification
  
  [✓] Tested default behavior (1 active lease limit).
  [✓] Tested property-level override (2 active leases).
  [✓] Verified fallback to system setting when property limit is 0.