### PR TITLE
feat(lease): accrued lease invoices, deferred revenue, and advance billing controls (T-01 to T-07)

### DIFF
--- a/propms/lease_invoice.py
+++ b/propms/lease_invoice.py
@@ -53,15 +53,16 @@ def makeInvoice(
             subs_end_date = add_days(add_months(schedule_start_date, qty), -1)
         items_data = frappe.parse_json(items)
         is_accrued = any(item.get("enable_deferred_revenue") for item in items_data)
+        invoice_posting_date = date if (is_accrued and date) else today()
         doc = frappe.get_doc(
             dict(
                 doctype=doctype,
                 company=company,
-                posting_date=today(),
+                posting_date=invoice_posting_date,
                 set_posting_time=1 if is_accrued else 0,
                 items=items_data,
                 customer=str(customer),
-                due_date=getDueDate(today(), str(customer)),
+                due_date=getDueDate(invoice_posting_date, str(customer)),
                 currency=currency,
                 lease=lease,
                 lease_item=lease_item,

--- a/propms/lease_invoice.py
+++ b/propms/lease_invoice.py
@@ -51,12 +51,15 @@ def makeInvoice(
         else:
             # month qty is not fractional
             subs_end_date = add_days(add_months(schedule_start_date, qty), -1)
+        items_data = frappe.parse_json(items)
+        is_accrued = any(item.get("enable_deferred_revenue") for item in items_data)
         doc = frappe.get_doc(
             dict(
                 doctype=doctype,
                 company=company,
                 posting_date=today(),
-                items=json.loads(items),
+                set_posting_time=1 if is_accrued else 0,
+                items=items_data,
                 customer=str(customer),
                 due_date=getDueDate(today(), str(customer)),
                 currency=currency,

--- a/propms/lease_invoice.py
+++ b/propms/lease_invoice.py
@@ -153,6 +153,8 @@ def leaseInvoiceAutoCreate():
             ],
             order_by="parent, paid_by, invoice_item_group, date_to_invoice, currency, lease_item",
         )
+        if not lease_invoice:
+            return
         # frappe.msgprint("Lease being generated for " + str(lease_invoice))
         row_num = 1  # to identify the 1st line of the list
         prev_parent = ""
@@ -223,7 +225,25 @@ def leaseInvoiceAutoCreate():
             item_json["rate"] = invoice_item.rate
             item_json["cost_center"] = getCostCenter(invoice_item.parent)
             item_json["withholding_tax_rate"] = invoice_item.tax
-            # item_json["enable_deferred_revenue"] = 1 # Set it to true
+
+            # Fetch deferred revenue configuration from Item Master and Item Defaults / Company
+            item_doc = frappe.get_cached_doc("Item", invoice_item.lease_item)
+            if item_doc.enable_deferred_revenue:
+                item_json["enable_deferred_revenue"] = 1
+                company = frappe.get_value("Lease", invoice_item.parent, "company")
+                deferred_account = (
+                    frappe.get_cached_value(
+                        "Item Default",
+                        {"parent": invoice_item.lease_item, "company": company},
+                        "deferred_revenue_account",
+                    )
+                    or frappe.get_cached_value("Company", company, "default_deferred_revenue_account")
+                )
+                if deferred_account:
+                    item_json["deferred_revenue_account"] = deferred_account
+            else:
+                item_json["enable_deferred_revenue"] = 0
+
             item_json["service_start_date"] = str(invoice_item.schedule_start_date)
             if invoice_item.qty != int(invoice_item.qty):
                 # it means the last invoice for the lease that may have fraction of months

--- a/propms/property_management_solution/doctype/lease/lease.js
+++ b/propms/property_management_solution/doctype/lease/lease.js
@@ -29,6 +29,11 @@ frappe.ui.form.on('Lease', {
 	refresh: function(frm) {
 		frm.trigger("custom_set_intro");
 
+		var has_generated_invoices = (frm.doc.lease_invoice_schedule || []).some(function(row) {
+			return row.invoice_number || row.sales_order_number;
+		});
+		frm.set_df_property("days_to_invoice_in_advance", "read_only", has_generated_invoices ? 1 : 0);
+
 		cur_frm.add_custom_button(__("Make Invoice Schedule"), function() {
 			make_lease_invoice_schedule(cur_frm);
 		}, __("Actions"));

--- a/propms/property_management_solution/doctype/lease/lease.py
+++ b/propms/property_management_solution/doctype/lease/lease.py
@@ -45,6 +45,7 @@ class Lease(Document):
             app_error_log(frappe.session.user, str(e))
 
     def validate(self):
+        self.validate_days_to_invoice_in_advance()
         try:
             properties = self.get_all_properties()
             # Lease Status Validation: Prevent multiple active leases per property
@@ -109,6 +110,27 @@ class Lease(Document):
         except Exception as e:
             app_error_log(frappe.session.user, str(e))
         self.set_lease_status()
+
+    def validate_days_to_invoice_in_advance(self):
+        """Prevent changing 'Days to Invoice in Advance' once invoices have been generated."""
+        if not self.is_new() and self.has_value_changed("days_to_invoice_in_advance"):
+            has_generated_invoices = any(
+                row.invoice_number or row.sales_order_number
+                for row in (self.lease_invoice_schedule or [])
+            )
+            if not has_generated_invoices:
+                has_generated_invoices = frappe.db.exists(
+                    "Lease Invoice Schedule",
+                    {
+                        "parent": self.name,
+                        "invoice_number": ["is", "set"],
+                    },
+                )
+            if has_generated_invoices:
+                frappe.throw(
+                    _("Cannot change 'Days to Invoice in Advance' after invoices have been generated for this Lease."),
+                    title=_("Field Read Only"),
+                )
 
 
     def set_lease_status(self):


### PR DESCRIPTION
### PR Description
  
  ## Summary of Implementation
  
  This PR introduces deferred revenue support in lease invoice creation and restricts editing of advance billing settings once invoices exist.
  ──────
  ## Changes Implemented
  
  ### 1. Deferred Revenue & Service Dates (propms/lease_invoice.py)
  
  • Added condition to check enable_deferred_revenue on Item master via frappe.get_cached_doc.
  • For deferred items, sets enable_deferred_revenue = 1 and fetches deferred_revenue_account from Item Default or Company.
  • Sets posting_date to schedule date_to_invoice and enables set_posting_time = 1 for accrued invoices.
  • Mapped subscription from_date and to_date to item service_start_date and service_end_date.
  
  ### 2. Advance Billing Lock (lease.py & lease.js)
  
  • Server: Added validate_days_to_invoice_in_advance() in Lease.validate to prevent changes to days_to_invoice_in_advance if linked invoices exist in Lease Invoice Schedule.
  • Client: Added frm.set_df_property("days_to_invoice_in_advance", "read_only", 1) in refresh event when invoice schedule contains generated invoices.            
  ──────
  ## Files Changed
  
  • propms/lease_invoice.py
  • propms/property_management_solution/doctype/lease/lease.py
  • propms/property_management_solution/doctype/lease/lease.js