### PR TITLE
fix(lease): preserve existing invoice schedules on advance days recalculation

### DIFF
--- a/propms/property_management_solution/doctype/lease/lease.js
+++ b/propms/property_management_solution/doctype/lease/lease.js
@@ -29,10 +29,6 @@ frappe.ui.form.on('Lease', {
 	refresh: function(frm) {
 		frm.trigger("custom_set_intro");
 
-		var has_generated_invoices = (frm.doc.lease_invoice_schedule || []).some(function(row) {
-			return row.invoice_number || row.sales_order_number;
-		});
-		frm.set_df_property("days_to_invoice_in_advance", "read_only", has_generated_invoices ? 1 : 0);
 
 		cur_frm.add_custom_button(__("Make Invoice Schedule"), function() {
 			make_lease_invoice_schedule(cur_frm);
@@ -204,6 +200,10 @@ var make_lease_invoice_schedule = function(frm){
 		args: {leasedoc: doc.name},
 		callback: function(){
 			cur_frm.reload_doc();
+			frappe.show_alert({
+				message: __("Completed making of invoice schedule."),
+				indicator: "green"
+			}, 5);
 		}
 	});
 };

--- a/propms/property_management_solution/doctype/lease/lease.py
+++ b/propms/property_management_solution/doctype/lease/lease.py
@@ -267,7 +267,7 @@ def make_lease_invoice_schedule(leasedoc):
 				"invoice_number",
 				"date_to_invoice",
 			],
-			filters={"parent": lease.name, "date_to_invoice": (">", lease.end_date)},
+			filters={"parent": lease.name, "schedule_start_date": (">", lease.end_date)},
 			parent_doctype="Lease",
 		)
 		for lease_invoice_schedule in lease_invoice_schedule_list:
@@ -340,7 +340,7 @@ def make_lease_invoice_schedule(leasedoc):
 						"date_to_invoice",
 					],
 					filters={"parent": lease.name, "lease_item": item.lease_item},
-					order_by="date_to_invoice",
+					order_by="schedule_start_date asc, creation asc",
 				)
 				# frappe.msgprint(str(lease_invoice_schedule_list))
 				# Get the latest item frequency incase lease was changed.
@@ -430,11 +430,8 @@ def make_lease_invoice_schedule(leasedoc):
 						idx += 1
 						invoice_date = add_days(invoice_period_end, 1)
 					# frappe.msgprint(str(lease_invoice_schedule))
-					# If the record already exists and invoice is generated
-					if (
-						lease_invoice_schedule.invoice_number is not None
-						and lease_invoice_schedule.invoice_number != ""
-					):
+					# If the record already exists
+					if True:
 						# frappe.msgprint("Lease Invoice Schedule retained: " + lease_invoice_schedule.name
 						# 	+ " for invoice number: " + str(lease_invoice_schedule.invoice_number)
 						# 	+ " dated " + str(lease_invoice_schedule.date_to_invoice)
@@ -457,10 +454,7 @@ def make_lease_invoice_schedule(leasedoc):
 							idx,
 						)
 						idx += 1
-					# If the invoice is not created
-					else:
-						# frappe.msgprint("Deleting schedule :" + lease_invoice_schedule.name + " dated: " + str(lease_invoice_schedule.date_to_invoice) + " for " + str(lease_invoice_schedule.lease_item))
-						frappe.delete_doc("Lease Invoice Schedule", lease_invoice_schedule.name)
+
 				# frappe.msgprint("first invoice_date: " + str(invoice_date), "Lease Invoice Schedule")
 				while end_date >= invoice_date:
 					invoice_period_end = add_days(add_months(invoice_date, frequency_factor), -1)
@@ -488,8 +482,6 @@ def make_lease_invoice_schedule(leasedoc):
 					)
 					idx += 1
 					invoice_date = add_days(invoice_period_end, 1)
-
-		frappe.msgprint("Completed making of invoice schedule.")
 
 	except Exception as e:
 		frappe.msgprint("Exception error! Check app error log.")


### PR DESCRIPTION
## Summary

Fixes invoice schedule recalculation in the Lease DocType so that changing **Days to Invoice in Advance** does not modify, delete, or regenerate existing invoice schedule dates.

Newly added lease periods are calculated independently using the updated advance setting.

## Changes

- Preserve existing un-invoiced invoice schedule records during recalculation.
- Prevent existing `date_to_invoice` values from being recalculated when advance days are changed.
- Process existing schedules chronologically using:
  - `schedule_start_date ASC`
  - `creation ASC`
- Fix cleanup logic to check `schedule_start_date > lease.end_date` instead of `date_to_invoice > lease.end_date`.
- Allow users to modify `days_to_invoice_in_advance` even after invoices have been created.
- Replace the blocking `frappe.msgprint` modal with a non-blocking `frappe.show_alert` notification.

## Problem

Previously, changing **Days to Invoice in Advance** could cause existing un-invoiced schedules to be deleted and regenerated with different `date_to_invoice` values.

Additionally, schedules were ordered by `date_to_invoice`, which could produce an incorrect sequence when schedules had different advance-day settings.

## Verification

### Initial Schedule

Created a monthly Lease from **September 2026 to December 2026** with:

- Days to Invoice in Advance: `5`

Generated schedules:

| Row | Schedule Period | Date to Invoice |
|---|---|---|
| 1 | Sep 2026 | 27-08-2026 |
| 2 | Oct 2026 | 26-09-2026 |
| 3 | Nov 2026 | 27-10-2026 |
| 4 | Dec 2026 | 26-11-2026 |

### Recalculation

Updated:

- Days to Invoice in Advance: `5 → 10`
- Lease End Date: `28-02-2027`

Then generated the Invoice Schedule again.

### Result

Existing schedules remained unchanged:

- 27-08-2026
- 26-09-2026
- 27-10-2026
- 26-11-2026

Only the newly added periods were generated using the updated `10` days advance:

| Row | Schedule Period | Date to Invoice |
|---|---|---|
| 5 | Jan 2027 | 22-12-2026 |
| 6 | Feb 2027 | 22-01-2027 |

Also verified that the completion notification is displayed as a floating green alert.

## Expected Behavior

Changing **Days to Invoice in Advance** should affect **only newly generated invoice schedule periods**. Existing schedule records and their invoice dates must remain untouched.